### PR TITLE
Address #18 - if telegram message is just a link, don't send as an embed in discord to preserve embed generation ability

### DIFF
--- a/src/telegram/handlers.ts
+++ b/src/telegram/handlers.ts
@@ -300,7 +300,12 @@ export function registerTelegramHandlers(bot: Bot, token: string): void {
         const sent = await textChannel.send({
           content: plainContent,
           ...(discordReplyRef
-            ? {reply: {failIfNotExists: false, messageReference: discordReplyRef}}
+            ? {
+                reply: {
+                  failIfNotExists: false,
+                  messageReference: discordReplyRef,
+                },
+              }
             : {}),
         });
         insertLink({

--- a/src/telegram/handlers.ts
+++ b/src/telegram/handlers.ts
@@ -82,6 +82,10 @@ function truncate(text: string, max: number): string {
   return `${text.slice(0, max - 1)}...`;
 }
 
+function isUrlOnly(text: string): boolean {
+  return /^https?:\/\/\S+$/.test(text.trim());
+}
+
 interface TelegramEntity {
   type: string;
   offset: number;
@@ -282,6 +286,33 @@ export function registerTelegramHandlers(bot: Bot, token: string): void {
         const excerpt = truncate(refText, 100);
         replyFieldValue = `**${refName}**: ${excerpt}`;
       }
+    }
+
+    // Link-only messages: send as plain text so Discord renders the link embed preview
+    if (
+      !ctx.message.photo &&
+      !ctx.message.document &&
+      !ctx.message.sticker &&
+      isUrlOnly(rawText)
+    ) {
+      const plainContent = `**${name}**: ${rawText.trim()}`;
+      try {
+        const sent = await textChannel.send({
+          content: plainContent,
+          ...(discordReplyRef
+            ? {reply: {failIfNotExists: false, messageReference: discordReplyRef}}
+            : {}),
+        });
+        insertLink({
+          discordChannelId: bridge.discord_channel_id,
+          discordMessageId: sent.id,
+          tgChatId: String(ctx.chat.id),
+          tgMessageId: ctx.message.message_id,
+        });
+      } catch (error) {
+        console.error('[tg-->discord] Failed to send message:', error);
+      }
+      return;
     }
 
     const embed = new EmbedBuilder()


### PR DESCRIPTION
Address #18 - if telegram message is just a link, don't send as an embed in discord to preserve embed generation ability